### PR TITLE
Calling on reponseBody.string() twice would cause a crash. Removing i…

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -598,13 +598,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                 } catch (ClassCastException ex) {
                     // unexpected response type
                     if (responseBody != null) {
-                        String responseBodyString = null;
-                        try {
-                            responseBodyString = responseBody.string();
-                        } catch(IOException exception) {
-                            exception.printStackTrace();
-                        }
-                        callback.invoke("Unexpected FileStorage response file: " + responseBodyString, null);
+                        callback.invoke("Unexpected FileStorage response with unknown file.", null);
                     } else {
                         callback.invoke("Unexpected FileStorage response with no file.", null);
                     }


### PR DESCRIPTION
…t in the catch